### PR TITLE
style: remove mt-4 on TabCard (larger screen)

### DIFF
--- a/src/components/NewTab/Tabs/TabCard.tsx
+++ b/src/components/NewTab/Tabs/TabCard.tsx
@@ -48,7 +48,7 @@ const TabCard = memo(function TabCard({
       />
       <a
         onClick={(e) => onOpenLink(e, tab)}
-        className="mt-4 line-clamp-2 max-w-full cursor-pointer flex-wrap hover:text-gray-500 hover:underline xl:mb-0 xl:line-clamp-none xl:flex"
+        className="mt-4 line-clamp-2 max-w-full cursor-pointer flex-wrap hover:text-gray-500 hover:underline xl:mb-0 xl:mt-0 xl:line-clamp-none xl:flex"
       >
         {tab.title}
       </a>


### PR DESCRIPTION
## Description

- Remove the top margin of Tabcard url text on larger screen(min-width:1280px)