### PR TITLE
Editable space names

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -341,3 +341,21 @@ chrome.runtime.onMessage.addListener(
     return true;
   },
 );
+
+chrome.runtime.onMessage.addListener(
+  async (request: RuntimeMessage, _, sendResponse) => {
+    if (request.action === "updateSpaceTitle") {
+      if (!request.userId || !request.spaceId || !request.newSpaceTitle) return;
+      const spaceDocRef = doc(
+        db,
+        "users",
+        request.userId,
+        "spaces",
+        request.spaceId,
+      );
+      await updateDoc(spaceDocRef, { title: request.newSpaceTitle });
+      sendResponse({ success: true });
+    }
+    return true;
+  },
+);

--- a/src/components/NewTab/Spaces/SpaceTab.tsx
+++ b/src/components/NewTab/Spaces/SpaceTab.tsx
@@ -12,6 +12,13 @@ interface SpaceTabProps {
   modalText: string;
   modalBtnText: string;
   isArchived: boolean;
+  isEditing?: boolean;
+  onSpaceTitleChange?: (
+    e: React.ChangeEvent<HTMLInputElement>,
+    id: string,
+  ) => void;
+  onSpaceTitleBlur?: (id: string) => void;
+  onEditSpace?: (id: string) => void;
 }
 
 const SpaceTab = ({
@@ -23,6 +30,10 @@ const SpaceTab = ({
   modalText,
   modalBtnText,
   isArchived,
+  isEditing,
+  onSpaceTitleBlur,
+  onSpaceTitleChange,
+  onEditSpace,
 }: SpaceTabProps) => {
   function openModal(id: string, action: string) {
     const modal = document.getElementById(
@@ -34,9 +45,32 @@ const SpaceTab = ({
     <li
       className={`relative border border-l-0 border-white p-4 text-xl ${linkClasses} group/space-tab flex justify-between hover:bg-orange-900`}
     >
-      <Link to={`/${id}`} className="w-full flex">
-        {title.toLowerCase()}
-      </Link>
+      {isEditing && onSpaceTitleChange && onSpaceTitleBlur && (
+        <input
+          type="text"
+          className="w-40 bg-transparent p-1 text-white"
+          value={title}
+          onChange={(e) => onSpaceTitleChange(e, id)}
+          onBlur={() => onSpaceTitleBlur(id)}
+          autoFocus
+        />
+      )}
+
+      {!isEditing && (
+        <Link
+          to={`/${id}`}
+          className="flex w-full"
+          onDoubleClick={(
+            e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+          ) => {
+            e.stopPropagation();
+            if (onEditSpace) onEditSpace(id);
+          }}
+        >
+          {title.toLowerCase()}
+        </Link>
+      )}
+
       <RemoveSpaceModal id={id} onRemoveSpace={onRemoveSpace} />
       <ToggleArchiveModal
         id={id}

--- a/src/components/NewTab/Spaces/SpaceTab.tsx
+++ b/src/components/NewTab/Spaces/SpaceTab.tsx
@@ -41,6 +41,13 @@ const SpaceTab = ({
     ) as HTMLDialogElement;
     modal.showModal();
   }
+  function handleKeyUp(e: React.KeyboardEvent<HTMLInputElement>, id: string) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (onSpaceTitleBlur) onSpaceTitleBlur(id);
+    }
+  }
   return (
     <li
       className={`relative border border-l-0 border-white p-4 text-xl ${linkClasses} group/space-tab flex justify-between hover:bg-orange-900`}
@@ -52,6 +59,7 @@ const SpaceTab = ({
           value={title}
           onChange={(e) => onSpaceTitleChange(e, id)}
           onBlur={() => onSpaceTitleBlur(id)}
+          onKeyUp={(e) => handleKeyUp(e, id)}
           autoFocus
         />
       )}

--- a/src/components/NewTab/Spaces/index.tsx
+++ b/src/components/NewTab/Spaces/index.tsx
@@ -16,6 +16,12 @@ interface SpacesProps {
   onOpenAddSpacePopup: () => void;
   onAddNewSpace: () => void;
   onRemoveSpace: (id: string) => void;
+  onSpaceEditBlur: (id: string) => void;
+  onSpaceTitleChange: (
+    e: React.ChangeEvent<HTMLInputElement>,
+    id: string,
+  ) => void;
+  onEditSpace: (id: string) => void;
   currentSpaceId?: string;
 }
 const Spaces = forwardRef(
@@ -25,6 +31,9 @@ const Spaces = forwardRef(
       onOpenAddSpacePopup,
       onAddNewSpace,
       onRemoveSpace,
+      onSpaceEditBlur,
+      onSpaceTitleChange,
+      onEditSpace,
       currentSpaceId,
     }: SpacesProps = props;
     console.log({ currentSpaceId });
@@ -87,6 +96,24 @@ const Spaces = forwardRef(
         inputRef.current.value = "";
       }
     }
+    function handleSpaceEditBlur(id: string) {
+      const space = spaces.find((space) => space.id === id);
+      if (!space) return;
+      if (space.isEditing) {
+        onSpaceEditBlur(id);
+      }
+    }
+    function handleSpaceTitleChange(
+      e: React.ChangeEvent<HTMLInputElement>,
+      id: string,
+    ) {
+      const space = spaces.find((space) => space.id === id);
+      if (!space) return;
+      onSpaceTitleChange(e, id);
+    }
+    function handleEditSpace(id: string) {
+      onEditSpace(id);
+    }
     return (
       <div className="fixed left-0 top-0 z-10 flex h-full w-72 flex-col bg-orange-700 opacity-80">
         <div className="h-16">
@@ -114,7 +141,7 @@ const Spaces = forwardRef(
           />
           <Toaster />
           <ul className="flex flex-col">
-            {spaces.map(({ id, title }) => {
+            {spaces.map(({ id, title, isEditing }) => {
               const linkClasses: string = `${
                 currentSpaceId === id
                   ? "text-yellow-400"
@@ -133,6 +160,10 @@ const Spaces = forwardRef(
                   modalText="Are you going to archive this space?"
                   modalBtnText="Archive"
                   isArchived={false}
+                  isEditing={isEditing}
+                  onSpaceTitleBlur={handleSpaceEditBlur}
+                  onSpaceTitleChange={handleSpaceTitleChange}
+                  onEditSpace={handleEditSpace}
                 ></SpaceTab>
               );
             })}

--- a/src/components/NewTab/index.tsx
+++ b/src/components/NewTab/index.tsx
@@ -460,6 +460,68 @@ const NewTab = () => {
   function toggleTabsLayout() {
     setIsTabsGrid((prev) => !prev);
   }
+  function handleSpaceTitleChange(
+    e: React.ChangeEvent<HTMLInputElement>,
+    id: string,
+  ) {
+    const newSpaces = spaces.map((space) => {
+      if (space.id === id) {
+        if (e.target.value.length > 10) {
+          toast.error("Space name should be less than 10 characters", {
+            className: "w-[400px] text-lg rounded-md shadow",
+          });
+          return space;
+        }
+        return {
+          ...space,
+          title: e.target.value,
+        };
+      }
+      return space;
+    });
+    setSpaces(newSpaces);
+  }
+  function handleEditSpace(id: string) {
+    const newSpaces = spaces.map((space) => {
+      if (space.id === id) {
+        return {
+          ...space,
+          isEditing: true,
+        };
+      }
+      return space;
+    });
+    setSpaces(newSpaces);
+  }
+  function handleSpaceEditBlur(id: string) {
+    const newSpaces = spaces.map((space) => {
+      if (space.id === id) {
+        return {
+          ...space,
+          isEditing: false,
+        };
+      }
+      return space;
+    });
+    setSpaces(newSpaces);
+    return new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(
+        {
+          action: "updateSpaceTitle",
+          spaceId: id,
+          newTitle: newSpaces.find((space) => space.id === id)?.title,
+          userId: currentUserId,
+        },
+        function (response) {
+          if (response) {
+            resolve(response);
+            return;
+          }
+          reject();
+        },
+      );
+    });
+  }
   return (
     <>
       <Header />
@@ -472,6 +534,9 @@ const NewTab = () => {
             onAddNewSpace={addNewSpace}
             currentSpaceId={activeSpaceId}
             onRemoveSpace={handleRemoveSpace}
+            onSpaceEditBlur={handleSpaceEditBlur}
+            onSpaceTitleChange={handleSpaceTitleChange}
+            onEditSpace={handleEditSpace}
           />
         )}
         <div className="flex w-4/5 flex-col">

--- a/src/components/NewTab/index.tsx
+++ b/src/components/NewTab/index.tsx
@@ -32,6 +32,7 @@ interface SpaceDoc {
 
 export interface Space extends SpaceDoc {
   id: string;
+  isEditing: boolean;
 }
 interface Response {
   success: boolean;
@@ -55,6 +56,7 @@ const NewTab = () => {
   // console.log("current order", tabOrder);
   console.log("current windowId", currentWindowId);
   console.log("current tabs", tabs);
+  console.log("current spaces", spaces);
   const archivedSpaces: string[] = useSpaceStore(
     (state) => state.archivedSpaces,
   );
@@ -165,7 +167,7 @@ const NewTab = () => {
         const currentSpaces: Space[] = [];
         querySnapshot.forEach((doc) => {
           const space = doc.data() as SpaceDoc;
-          currentSpaces.push({ id: doc.id, ...space });
+          currentSpaces.push({ id: doc.id, isEditing: false, ...space });
         });
         setSpaces(currentSpaces);
         const currentActiveId = currentSpaces.find(
@@ -343,7 +345,10 @@ const NewTab = () => {
       { action: "addSpace", newSpaceTitle, userId: currentUserId },
       function (response) {
         if (response) {
-          setSpaces((s) => [...s, { title: newSpaceTitle, id: response.id }]);
+          setSpaces((s) => [
+            ...s,
+            { title: newSpaceTitle, isEditing: false, id: response.id },
+          ]);
           return;
         }
       },

--- a/src/components/NewTab/index.tsx
+++ b/src/components/NewTab/index.tsx
@@ -509,7 +509,7 @@ const NewTab = () => {
         {
           action: "updateSpaceTitle",
           spaceId: id,
-          newTitle: newSpaces.find((space) => space.id === id)?.title,
+          newSpaceTitle: newSpaces.find((space) => space.id === id)?.title,
           userId: currentUserId,
         },
         function (response) {


### PR DESCRIPTION
## Description
- Make space titles editable.
- Users can double-click the space tab to edit the space titles.
- Persists the space names in Firestore.