### PR TITLE
hot-fix: spaces disappear when a space link is clicked

### DIFF
--- a/src/components/NewTab/Spaces/index.tsx
+++ b/src/components/NewTab/Spaces/index.tsx
@@ -127,7 +127,7 @@ const Spaces = forwardRef(
             <img src={tabs} className="block h-12 w-12" />
           </Link>
         </div>
-        {location.pathname === "/" && (
+        {!location.pathname.includes("webtime") && (
           <div className="flex max-h-full w-full flex-col">
             <div className="flex items-center gap-3 pl-4 pt-10">
               <div className="h-4 w-4">


### PR DESCRIPTION
## Description

- Update the conditions to only hide spaces on URL starting with "webtime"